### PR TITLE
fix __VA_ARGS__ on windows unfold error and register_handler name error

### DIFF
--- a/common/plugin.hpp
+++ b/common/plugin.hpp
@@ -35,7 +35,7 @@ namespace purecpp{
 
     template<typename Self, typename Function>
     int register_handler(Self&& self, std::string const& name, const Function& f) {
-      register_handler(name, f, &self);
+      purecpp::router::get().register_handler(name, f, &self);
 
       return 0;
     }
@@ -55,13 +55,15 @@ BOOST_DLL_ALIAS(purecpp::get_key, get_key);
 #define CAT( A, B ) A ## B
 #define SELECT( NAME, NUM ) CAT( NAME ## _, NUM )
 
+#define EXPAND( ... ) __VA_ARGS__
+
 #define VA_NARGS_IMPL(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, N, ...) N
-#define VA_NARGS(...) VA_NARGS_IMPL(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
-#define VA_SIZE(...)   VA_NARGS(__VA_ARGS__)
+#define VA_NARGS(...) EXPAND(VA_NARGS_IMPL(__VA_ARGS__, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1))
+#define VA_SIZE(...)   EXPAND(VA_NARGS(__VA_ARGS__))
 
-#define VA_SELECT( NAME, ... ) SELECT( NAME, VA_SIZE(__VA_ARGS__) )(__VA_ARGS__)
+#define VA_SELECT( NAME, ... ) EXPAND(SELECT( NAME, VA_SIZE(__VA_ARGS__) )(__VA_ARGS__))
 
-#define ADD_SERVICE( ... ) VA_SELECT( MY_OVERLOADED, __VA_ARGS__ )
+#define ADD_SERVICE( ... ) EXPAND(VA_SELECT( MY_OVERLOADED, __VA_ARGS__ ))
 
 #define MY_OVERLOADED_1( f ) int ANONYMOUS_VARIABLE(var) = purecpp::register_handler(#f, f);
 #define MY_OVERLOADED_2( f, t ) int ANONYMOUS_VARIABLE(var) = purecpp::register_handler(#f, f, t);


### PR DESCRIPTION
1. `__VA_ARGS__ `在windows上visual studio上不能正确展开，只能被识别为一个参数。
    1）可以在cmake中添加`set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:preprocessor")`，但是会带来一些警告。
    2）通过宏`#define EXPAND( ... ) __VA_ARGS__`再转一层可以解决。
2.
```c++
template<typename Self, typename Function>
int register_handler(Self&& self, std::string const& name, const Function& f) {
  register_handler(name, f, &self);
  return 0;
}
```
`register_handler(name, f, &self);`会导致name少了首字母